### PR TITLE
Ex lock

### DIFF
--- a/gilmour.gemspec
+++ b/gilmour.gemspec
@@ -7,16 +7,16 @@ Gem::Specification.new do |s|
 	s.version     = Gilmour::VERSION
 	s.platform    = Gem::Platform::RUBY
 	s.authors     = ["Aditya Godbole"]
-	s.email       = ["aditya.a.godbole@gmail.com"]
+	s.email       = ["code.aa@gdbl.me"]
 	s.homepage    = ""
 	s.summary     = %q{A Sinatra like DSL for implementing AMQP services}
 	s.description = %q{This gem provides a Sinatra like DSL and a simple protocol to enable writing services that communicate over AMQP}
 
 	s.add_development_dependency "rspec"
-  s.add_dependency "mash"
-  s.add_dependency "redis"
-  s.add_dependency "em-hiredis"
-  s.add_dependency "amqp"
+	s.add_dependency "mash"
+	s.add_dependency "redis"
+	s.add_dependency "em-hiredis"
+	s.add_dependency "amqp"
 
 	s.files         = `git ls-files`.split("\n")
 	s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/gilmour/backends/redis.rb
+++ b/lib/gilmour/backends/redis.rb
@@ -55,7 +55,7 @@ module Gilmour
 
     def pmessage_handler(key, matched_topic, payload)
       @subscriptions[key].each do |subscription|
-        execute_handler(matched_topic, payload, subscription[:handler])
+        execute_handler(matched_topic, payload, subscription)
       end
     end
 
@@ -63,6 +63,12 @@ module Gilmour
       topic = "response.#{sender}"
       @response_handlers[topic] = handler
       subscribe_topic(topic)
+    end
+
+    def acquire_ex_lock(sender)
+      @publisher.set(sender, sender, 'EX', 600, 'NX') do |val|
+        yield val if val && block_given?
+      end
     end
 
     def response_handler(sender, payload)

--- a/lib/gilmour/base.rb
+++ b/lib/gilmour/base.rb
@@ -34,10 +34,10 @@ module Gilmour
         @@registered_services
       end
 
-      def listen_to(topic)
+      def listen_to(topic, excl = false)
         handler = Proc.new
         @@subscribers[topic] ||= []
-        @@subscribers[topic] << { handler: handler, subscriber: self }
+        @@subscribers[topic] << { handler: handler, subscriber: self , exclusive: excl}
       end
 
       def subscribers(topic = nil)

--- a/version.rb
+++ b/version.rb
@@ -1,3 +1,3 @@
 module Gilmour
-    VERSION = '0.0.9'
+    VERSION = '0.1.0'
 end


### PR DESCRIPTION
Add a second parameter to `listen_to` which determines if only one microservice instance can execute a given request at a time. By default, it acts as a broadcast. The exclusive option should be made default in the future. For backward compatibility it is otherwise.
